### PR TITLE
feat: CI/CD build pipeline (closes #25)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,103 @@
+name: CI
+
+on:
+  push:
+    branches: [master]
+    tags: ['v*.*.*']
+  pull_request:
+    branches: [master]
+
+jobs:
+  # ─── Typecheck ───────────────────────────────────────────────────────────────
+  # Runs on every push and PR. Does not require native module rebuild.
+  typecheck:
+    name: Typecheck
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+
+      - name: Install dependencies (skip native rebuild)
+        run: npm ci --ignore-scripts
+
+      - name: Typecheck
+        run: npm run typecheck
+
+  # ─── Build ───────────────────────────────────────────────────────────────────
+  # Runs only on version tags (e.g. v1.2.3). Produces platform artifacts.
+  build:
+    name: Build (${{ matrix.os }})
+    if: startsWith(github.ref, 'refs/tags/v')
+    needs: typecheck
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: ubuntu-latest
+            script: build:linux
+            artifacts: 'dist/*.AppImage dist/*.deb'
+          - os: macos-latest
+            script: build:mac
+            artifacts: 'dist/*.dmg'
+          - os: windows-latest
+            script: build:win
+            artifacts: 'dist/*.exe'
+
+    runs-on: ${{ matrix.os }}
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci --ignore-scripts
+
+      - name: Rebuild native modules for Electron
+        run: npm run postinstall
+
+      # Skip code signing until certificates are available
+      - name: Build
+        env:
+          CSC_IDENTITY_AUTO_DISCOVERY: false
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: npm run ${{ matrix.script }}
+
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: mailtap-${{ matrix.os }}
+          path: ${{ matrix.artifacts }}
+          if-no-files-found: error
+
+  # ─── Release ─────────────────────────────────────────────────────────────────
+  # Creates a GitHub Release and attaches all build artifacts.
+  release:
+    name: Release
+    if: startsWith(github.ref, 'refs/tags/v')
+    needs: build
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+
+    steps:
+      - name: Download all artifacts
+        uses: actions/download-artifact@v4
+        with:
+          path: artifacts
+          merge-multiple: true
+
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          files: artifacts/**
+          generate_release_notes: true
+          draft: false
+          prerelease: ${{ contains(github.ref_name, '-') }}

--- a/package.json
+++ b/package.json
@@ -20,7 +20,8 @@
     "postinstall": "electron-builder install-app-deps",
     "build:unpack": "npm run build && electron-builder --dir",
     "build:mac": "npm run build && electron-builder --mac",
-    "build:linux": "npm run build && electron-builder --linux"
+    "build:linux": "npm run build && electron-builder --linux",
+    "build:win": "npm run build && electron-builder --win"
   },
   "dependencies": {
     "@ant-design/icons": "^5.5.2",
@@ -97,6 +98,21 @@
       ],
       "icon": "build/icon.icns",
       "category": "public.app-category.productivity"
+    },
+    "win": {
+      "target": [
+        {
+          "target": "nsis",
+          "arch": [
+            "x64"
+          ]
+        }
+      ],
+      "icon": "build/icon.ico"
+    },
+    "nsis": {
+      "oneClick": false,
+      "allowToChangeInstallationDirectory": true
     }
   }
 }


### PR DESCRIPTION
## Summary

- Adds `.github/workflows/ci.yml` with three jobs
- Adds `build:win` script and Windows NSIS installer target to `package.json`

## Jobs

**`typecheck`** — runs on every push to `master` and every PR. Installs deps without native rebuild (`--ignore-scripts`) for speed, then runs `npm run typecheck`. This is the fast feedback loop for development.

**`build`** — runs only when a version tag is pushed (e.g. `git tag v1.0.0 && git push --tags`). Builds in parallel on three runners:
| Runner | Script | Artifacts |
|---|---|---|
| `ubuntu-latest` | `build:linux` | `.AppImage`, `.deb` |
| `macos-latest` | `build:mac` | `.dmg` (arm64 + x64) |
| `windows-latest` | `build:win` | `.exe` (NSIS installer) |

Native modules (`better-sqlite3`) are rebuilt for Electron's ABI on each runner via `npm run postinstall`. Code signing is disabled (`CSC_IDENTITY_AUTO_DISCOVERY=false`) until certificates are ready — that's tracked separately in #19, #20, #22.

**`release`** — runs after all three builds succeed. Downloads all artifacts and creates a GitHub Release with auto-generated release notes. Tags containing a hyphen (e.g. `v1.0.0-beta.1`) are automatically marked as pre-releases.

## Usage

```bash
# Trigger a release
git tag v1.0.0
git push origin v1.0.0
```

Closes #25

🤖 Generated with [Claude Code](https://claude.com/claude-code)